### PR TITLE
Makefile flexibility and python modernization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+CXX=clang++
+
 bounce: bounce.cc
-	clang++ -ansi -pedantic -Wall -obounce bounce.cc
+	${CXX} -ansi -pedantic -Wall -obounce bounce.cc
 
 clean:
 	rm -f bounce bounce.o

--- a/test_bounce.py
+++ b/test_bounce.py
@@ -16,7 +16,7 @@ import pytest
 
 
 def test_output_ignore_whitespace():
-    reference_output = open('bounce_reference_output.txt', 'tr').readlines()
+    reference_output = open('bounce_reference_output.txt', 'tr')
     status, output = subprocess.getstatusoutput('./bounce > output.txt')
     for ref, cur in zip(reference_output, output.splitlines()):
         assert ref.index('x') == cur.index('x')
@@ -25,7 +25,7 @@ def test_output_ignore_whitespace():
 
     
 def test_output_2_particles():
-    reference_output = open('bounce_reference_output-2.txt', 'tr').readlines()
+    reference_output = open('bounce_reference_output-2.txt', 'tr')
     status, output = subprocess.getstatusoutput('./bounce > output.txt')
     for ref, cur in zip(reference_output, output.splitlines()):
         assert ref.index('x') == cur.index('x')


### PR DESCRIPTION
The makefile had a hard-wired C++ compiler. The proposed change allows an alternative compiler to be specified on the command line, thus:

```
make CXX=myC++
```

The original test code used `open(...).readlines()` and later iterated over the result with a for loop. In modern Python one should simply iterate over the result of `open(...)`.
